### PR TITLE
Change the classname of `TRVSXcode`

### DIFF
--- a/CleanHeaders.xcodeproj/project.pbxproj
+++ b/CleanHeaders.xcodeproj/project.pbxproj
@@ -7,12 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		931BFD741BC48F22007C3D5A /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 931BFD731BC48F22007C3D5A /* AppKit.framework */; settings = {ASSET_TAGS = (); }; };
-		931BFD761BC48F22007C3D5A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 931BFD751BC48F22007C3D5A /* Foundation.framework */; settings = {ASSET_TAGS = (); }; };
+		931BFD741BC48F22007C3D5A /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 931BFD731BC48F22007C3D5A /* AppKit.framework */; };
+		931BFD761BC48F22007C3D5A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 931BFD751BC48F22007C3D5A /* Foundation.framework */; };
 		931BFD7A1BC48F22007C3D5A /* CleanHeaders.xcscheme in Resources */ = {isa = PBXBuildFile; fileRef = 931BFD791BC48F22007C3D5A /* CleanHeaders.xcscheme */; };
 		931BFD7D1BC48F22007C3D5A /* CleanHeaders.m in Sources */ = {isa = PBXBuildFile; fileRef = 931BFD7C1BC48F22007C3D5A /* CleanHeaders.m */; };
 		931BFD801BC48F22007C3D5A /* NSObject_Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 931BFD7F1BC48F22007C3D5A /* NSObject_Extension.m */; };
-		9351B9151BC495E400421C88 /* TRVSXcode.m in Sources */ = {isa = PBXBuildFile; fileRef = 9351B9141BC495E400421C88 /* TRVSXcode.m */; settings = {ASSET_TAGS = (); }; };
+		9351B9151BC495E400421C88 /* CHTRVSXcode.m in Sources */ = {isa = PBXBuildFile; fileRef = 9351B9141BC495E400421C88 /* CHTRVSXcode.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -25,8 +25,8 @@
 		931BFD7E1BC48F22007C3D5A /* NSObject_Extension.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSObject_Extension.h; sourceTree = "<group>"; };
 		931BFD7F1BC48F22007C3D5A /* NSObject_Extension.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSObject_Extension.m; sourceTree = "<group>"; };
 		931BFD811BC48F22007C3D5A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		9351B9131BC495E400421C88 /* TRVSXcode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TRVSXcode.h; sourceTree = "<group>"; };
-		9351B9141BC495E400421C88 /* TRVSXcode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRVSXcode.m; sourceTree = "<group>"; };
+		9351B9131BC495E400421C88 /* CHTRVSXcode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHTRVSXcode.h; sourceTree = "<group>"; };
+		9351B9141BC495E400421C88 /* CHTRVSXcode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CHTRVSXcode.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -93,8 +93,8 @@
 		931BFD871BC48F83007C3D5A /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
-				9351B9131BC495E400421C88 /* TRVSXcode.h */,
-				9351B9141BC495E400421C88 /* TRVSXcode.m */,
+				9351B9131BC495E400421C88 /* CHTRVSXcode.h */,
+				9351B9141BC495E400421C88 /* CHTRVSXcode.m */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -166,7 +166,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9351B9151BC495E400421C88 /* TRVSXcode.m in Sources */,
+				9351B9151BC495E400421C88 /* CHTRVSXcode.m in Sources */,
 				931BFD7D1BC48F22007C3D5A /* CleanHeaders.m in Sources */,
 				931BFD801BC48F22007C3D5A /* NSObject_Extension.m in Sources */,
 			);

--- a/CleanHeaders/CleanHeaders.m
+++ b/CleanHeaders/CleanHeaders.m
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Karthikeya Udupa K M. All rights reserved.
 //
 
-#import "TRVSXcode.h"
+#import "CHTRVSXcode.h"
 #import "CleanHeaders.h"
 
 @interface CleanHeaders ()
@@ -57,13 +57,13 @@
  *  Actual action to clean the header.
  */
 - (void)cleanHeaderAction {
-  if (![TRVSXcode textViewHasSelection]) {
+  if (![CHTRVSXcode textViewHasSelection]) {
     [self formatRanges:@[
-      [NSValue valueWithRange:[TRVSXcode wholeRangeOfTextView]]
-    ] inDocument:[TRVSXcode sourceCodeDocument]];
+      [NSValue valueWithRange:[CHTRVSXcode wholeRangeOfTextView]]
+    ] inDocument:[CHTRVSXcode sourceCodeDocument]];
   } else {
-    [self formatRanges:[[TRVSXcode textView] selectedRanges]
-            inDocument:[TRVSXcode sourceCodeDocument]];
+    [self formatRanges:[[CHTRVSXcode textView] selectedRanges]
+            inDocument:[CHTRVSXcode sourceCodeDocument]];
   }
 }
 

--- a/CleanHeaders/Helpers/CHTRVSXcode.h
+++ b/CleanHeaders/Helpers/CHTRVSXcode.h
@@ -123,7 +123,7 @@
 @property (readonly) IDEWorkspace *workspace;
 @end
 
-@interface TRVSXcode : NSObject
+@interface CHTRVSXcode : NSObject
 
 + (IDESourceCodeDocument *)sourceCodeDocument;
 + (NSTextView *)textView;

--- a/CleanHeaders/Helpers/CHTRVSXcode.m
+++ b/CleanHeaders/Helpers/CHTRVSXcode.m
@@ -6,9 +6,9 @@
 //  Copyright (c) 2014 Travis Jeffery. All rights reserved.
 //
 
-#import "TRVSXcode.h"
+#import "CHTRVSXcode.h"
 
-@implementation TRVSXcode
+@implementation CHTRVSXcode
 
 + (id)currentEditor {
   if ([[self windowController]

--- a/CleanHeaders/Info.plist
+++ b/CleanHeaders/Info.plist
@@ -23,24 +23,25 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>DVTPlugInCompatibilityUUIDs</key>
-	<array>
-		<string>0420B86A-AA43-4792-9ED0-6FE0F2B16A13</string>
-		<string>CC0D0F4F-05B3-431A-8F33-F84AFCB2C651</string>
-		<string>0420B86A-AA43-4792-9ED0-6FE0F2B16A13</string>
-		<string>AABB7188-E14E-4433-AD3B-5CD791EAD9A3</string>
-		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
-		<string>8DC44374-2B35-4C57-A6FE-2AD66A36AAD9</string>
-		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
-		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
-		<string>FEC992CC-CA4A-4CFD-8881-77300FCB848A</string>
-		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
-		<string>640F884E-CE55-4B40-87C0-8869546CAB7A</string>
-		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
-		<string>AD68E85B-441B-4301-B564-A45E4919A6AD</string>
-		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
-		<string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
-		<string>7265231C-39B4-402C-89E1-16167C4CC990</string>
-	</array>
+    <array>
+        <string>9AFF134A-08DC-4096-8CEE-62A4BB123046</string>
+        <string>7265231C-39B4-402C-89E1-16167C4CC990</string>
+        <string>0420B86A-AA43-4792-9ED0-6FE0F2B16A13</string>
+        <string>CC0D0F4F-05B3-431A-8F33-F84AFCB2C651</string>
+        <string>0420B86A-AA43-4792-9ED0-6FE0F2B16A13</string>
+        <string>AABB7188-E14E-4433-AD3B-5CD791EAD9A3</string>
+        <string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
+        <string>8DC44374-2B35-4C57-A6FE-2AD66A36AAD9</string>
+        <string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
+        <string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
+        <string>FEC992CC-CA4A-4CFD-8881-77300FCB848A</string>
+        <string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
+        <string>640F884E-CE55-4B40-87C0-8869546CAB7A</string>
+        <string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
+        <string>AD68E85B-441B-4301-B564-A45E4919A6AD</string>
+        <string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
+        <string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
+    </array>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
This is used by Travis's original Clang Format Xcode plugin, so whenever both this plugin and ClangFormat-Xcode are loaded together, users will see:

```
objc[96338]: Class TRVSXcode is implemented in both /Users/tonyarnold/Library/Application Support/Developer/Shared/Xcode/Plug-ins/CleanHeaders.xcplugin/Contents/MacOS/CleanHeaders and /Users/tonyarnold/Library/Application Support/Developer/Shared/Xcode/Plug-ins/ClangFormat.xcplugin/Contents/MacOS/ClangFormat. One of the two will be used. Which one is undefined.
```
